### PR TITLE
set containers to run as nonroot user 'abc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Docker + VNC + noVNC web UI
 
 #### Misc
 
-- `-e ROOT_PASSWORD=password`
+- `-e VNC_PASSWORD=password`
+- `-e PUID=1000` - The user uid which can be used to match a host's user.
+- `-e PGID=1000` - the user's main group id which can be used to match a host's group
 
 ### Common Ports
 
@@ -34,7 +36,7 @@ Docker + VNC + noVNC web UI
 
 ### Common Volumes
 
-- `-v ./appconfig:/root`
+- `-v ./appconfig:/home/abc`
 
 ## Images
 

--- a/applications/adobe_acrobat/root/etc/cont-init.d/03-desktop.sh
+++ b/applications/adobe_acrobat/root/etc/cont-init.d/03-desktop.sh
@@ -3,4 +3,4 @@
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/AdobeReader.desktop > /root/Desktop/AdobeReader.desktop
+cat /usr/share/applications/AdobeReader.desktop > /home/abc/Desktop/AdobeReader.desktop

--- a/applications/adobe_acrobat/root/etc/cont-init.d/03-desktop.sh
+++ b/applications/adobe_acrobat/root/etc/cont-init.d/03-desktop.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/AdobeReader.desktop > /home/abc/Desktop/AdobeReader.desktop
+cat /usr/share/applications/AdobeReader.desktop > "$HOME/Desktop/AdobeReader.desktop"

--- a/applications/browsers/Dockerfile
+++ b/applications/browsers/Dockerfile
@@ -3,7 +3,7 @@ FROM msjpq/firefox-vnc
 # Install
 RUN apt update && \
     apt install -y chromium-browser
-VOLUME /root/Downloads
+VOLUME /home/abc/Downloads
 
 
 # All Dependencies Satisfied

--- a/applications/firefox/Dockerfile
+++ b/applications/firefox/Dockerfile
@@ -3,7 +3,7 @@ FROM msjpq/kde-vnc:bionic
 # Install
 RUN apt update && \
     apt install -y firefox
-VOLUME /root/Downloads
+VOLUME /home/abc/Downloads
 
 
 # All Dependencies Satisfied

--- a/applications/firefox/root/etc/cont-init.d/02-desktop.sh
+++ b/applications/firefox/root/etc/cont-init.d/02-desktop.sh
@@ -3,4 +3,4 @@
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/firefox.desktop > /root/Desktop/firefox.desktop
+cat /usr/share/applications/firefox.desktop > /home/abc/Desktop/firefox.desktop

--- a/applications/firefox/root/etc/cont-init.d/02-desktop.sh
+++ b/applications/firefox/root/etc/cont-init.d/02-desktop.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/firefox.desktop > /home/abc/Desktop/firefox.desktop
+cat /usr/share/applications/firefox.desktop > "$HOME/Desktop/firefox.desktop"

--- a/applications/motrix/Dockerfile
+++ b/applications/motrix/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /_install
 # Install
 ADD https://github.com/agalwood/Motrix/releases/download/v${VERSION}/Motrix_${VERSION}_amd64.deb /_install
 RUN apt install -y /_install/Motrix_${VERSION}_amd64.deb
-VOLUME /root/Downloads
+VOLUME /home/abc/Downloads
 
 
 # All Dependencies Satisfied

--- a/applications/motrix/root/etc/cont-init.d/02-desktop.sh
+++ b/applications/motrix/root/etc/cont-init.d/02-desktop.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/motrix.desktop > /root/Desktop/motrix.desktop
+cat /usr/share/applications/motrix.desktop > "$HOME/Desktop/motrix.desktop"

--- a/base/_root/etc/cont-init.d/00-createuser.sh
+++ b/base/_root/etc/cont-init.d/00-createuser.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/with-contenv bash
+
+# root
+echo "root:`echo $(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 20)`" | chpasswd
+
+
+# https://github.com/linuxserver/docker-baseimage-alpine/blob/master/root/etc/cont-init.d/10-adduser
+#abc
+PUID=${PUID:-911}
+PGID=${PGID:-911}
+
+# create abc user
+useradd -u "$PUID" -U -d /home/abc -s /bin/false abc
+groupmod -o -g "$PGID" abc
+echo "abc:`echo $(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 20)`" | chpasswd
+
+# ensure abc user has normal default settings
+cp /etc/skel/.bash_logout $HOME/
+cp /etc/skel/.bashrc $HOME/
+cp /etc/skel/.profile $HOME/
+echo export XDG_RUNTIME_DIR="/tmp/runtime-abc" >> $HOME/.bashrc
+mkdir -p "$HOME/Desktop"
+mkdir -p "$HOME/.vnc"
+
+# Needed when we run startplasma-x11 to prevent warnings
+mkdir -p /tmp/runtime-abc
+chmod 700 /tmp/runtime-abc
+chown abc:abc /tmp/runtime-abc
+
+echo "$VNC_PASSWORD" | vncpasswd -f >> "$HOME/.vnc/passwd"
+chmod 600 "$HOME/.vnc/passwd"
+
+echo '
+-------------------------------------
+GID/UID
+-------------------------------------'
+echo "
+User uid:    $(id -u abc)
+User gid:    $(id -g abc)
+-------------------------------------
+"

--- a/base/_root/etc/cont-init.d/00-desktop.sh
+++ b/base/_root/etc/cont-init.d/00-desktop.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-set -o pipefail
-
-mkdir -p /misc/desktop /root/Desktop
-mv /misc/desktop/* /root/Desktop

--- a/base/_root/etc/cont-init.d/01-desktop.sh
+++ b/base/_root/etc/cont-init.d/01-desktop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+set -eu
+set -o pipefail
+
+mkdir -p /misc/desktop "$HOME/Desktop"
+mv /misc/desktop/* "$HOME/Desktop"

--- a/base/_root/etc/cont-init.d/99-fixuserpermissions.sh
+++ b/base/_root/etc/cont-init.d/99-fixuserpermissions.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+#TODO: update this file to use s6-overlay feature /etc/fix-attrs.d
+chown -R abc:abc $HOME

--- a/base/_root/etc/services.d/novnc/run
+++ b/base/_root/etc/services.d/novnc/run
@@ -3,4 +3,4 @@
 set -eu
 set -o pipefail
 
-/novnc/utils/launch.sh
+s6-setuidgid abc /novnc/utils/launch.sh

--- a/base/_root/etc/services.d/tigervnc/run
+++ b/base/_root/etc/services.d/tigervnc/run
@@ -3,4 +3,4 @@
 set -eu
 set -o pipefail
 
-/usr/bin/Xvnc "$DISPLAY" -geometry "$SCR_WIDTH"x"$SCR_HEIGHT" -depth 16 -SecurityTypes none -AlwaysShared
+s6-setuidgid abc /usr/bin/Xvnc "$DISPLAY" -geometry "$SCR_WIDTH"x"$SCR_HEIGHT" -depth 16 -PasswordFile=$HOME/.vnc/passwd

--- a/base/_root/etc/services.d/vncconfig/run
+++ b/base/_root/etc/services.d/vncconfig/run
@@ -3,4 +3,4 @@
 set -eu
 set -o pipefail
 
-vncconfig -nowin
+s6-setuidgid abc vncconfig -nowin

--- a/base/bionic/Dockerfile
+++ b/base/bionic/Dockerfile
@@ -46,14 +46,12 @@ EXPOSE 8080
 ENV PATH_PREFIX=/ \
     VNC_RESIZE=scale \
     RECON_DELAY=250 \
-    PAGE_TITLE=KDE
+    PAGE_TITLE=KDE \
+    HOME=/home/abc
 
 
-## Setup Root User
-ENV ROOT_PASSWORD=password
-RUN echo "root:$ROOT_PASSWORD" | chpasswd
-WORKDIR /root
-VOLUME /root
+WORKDIR /home/abc
+VOLUME /home/abc
 
 
 ## All Dependencies Satisfied

--- a/base/bionic/root/etc/cont-init.d/01-desktop.sh
+++ b/base/bionic/root/etc/cont-init.d/01-desktop.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/nautilus.desktop > /root/Desktop/nautilus.desktop
-cat /usr/share/applications/org.kde.konsole.desktop > /root/Desktop/konsole.desktop
+cat /usr/share/applications/nautilus.desktop > "$HOME/Desktop/nautilus.desktop"
+cat /usr/share/applications/org.kde.konsole.desktop > "$HOME/Desktop/konsole.desktop"

--- a/base/bionic/root/etc/cont-init.d/01-nolock.sh
+++ b/base/bionic/root/etc/cont-init.d/01-nolock.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-mkdir -p /root/.config
-mv /misc/kscreenlockerrc /root/.config/kscreenlockerrc
+mkdir -p "$HOME/.config"
+mv /misc/kscreenlockerrc "$HOME/.config/kscreenlockerrc"

--- a/base/bionic/root/etc/services.d/kde/run
+++ b/base/bionic/root/etc/services.d/kde/run
@@ -3,4 +3,5 @@
 set -eu
 set -o pipefail
 
-/usr/bin/startkde
+export XDG_RUNTIME_DIR="/tmp/runtime-abc"
+s6-setuidgid abc /usr/bin/startkde

--- a/base/focal/Dockerfile
+++ b/base/focal/Dockerfile
@@ -46,14 +46,12 @@ EXPOSE 8080
 ENV PATH_PREFIX=/ \
     VNC_RESIZE=scale \
     RECON_DELAY=250 \
-    PAGE_TITLE=KDE
+    PAGE_TITLE=KDE \
+    HOME=/home/abc
 
 
-## Setup Root User
-ENV ROOT_PASSWORD=password
-RUN echo "root:$ROOT_PASSWORD" | chpasswd
-WORKDIR /root
-VOLUME /root
+WORKDIR /home/abc
+VOLUME /home/abc
 
 
 ## All Dependencies Satisfied

--- a/base/focal/root/etc/cont-init.d/01-desktop.sh
+++ b/base/focal/root/etc/cont-init.d/01-desktop.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-cat /usr/share/applications/org.kde.dolphin.desktop > /root/Desktop/dolphin.desktop
-cat /usr/share/applications/org.kde.konsole.desktop > /root/Desktop/konsole.desktop
+cat /usr/share/applications/org.kde.dolphin.desktop > "$HOME/Desktop/dolphin.desktop"
+cat /usr/share/applications/org.kde.konsole.desktop > "$HOME/Desktop/konsole.desktop"

--- a/base/focal/root/etc/cont-init.d/01-nolock.sh
+++ b/base/focal/root/etc/cont-init.d/01-nolock.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 set -eu
 set -o pipefail
 
-mkdir -p /root/.config
-mv /misc/kscreenlockerrc /root/.config/kscreenlockerrc
+mkdir -p "$HOME/.config"
+mv /misc/kscreenlockerrc "$HOME/.config/kscreenlockerrc"

--- a/base/focal/root/etc/services.d/kde/run
+++ b/base/focal/root/etc/services.d/kde/run
@@ -3,4 +3,5 @@
 set -eu
 set -o pipefail
 
-/usr/bin/startplasma-x11
+export XDG_RUNTIME_DIR="/tmp/runtime-abc"
+s6-setuidgid abc /usr/bin/startplasma-x11


### PR DESCRIPTION
 - set kde, vncconfig, tigervnc, novnc as user abc
 - user abc uid and gid can bet set via ENV
 - no longer can escalate to root in the container. software must be installed either when building the image or running the container
 - password protected via novnc through tigervnc
 
sources:
 - https://github.com/just-containers/s6-overlay#features
 - https://github.com/linuxserver/docker-baseimage-alpine/blob/master/root/etc/cont-init.d/10-adduser
 - https://github.com/ConSol/docker-headless-vnc-container